### PR TITLE
Hyunwoo: [Level 1] 완주하지 못한 선수, [Level 2] 위장, 전화번호 목록

### DIFF
--- a/Hash/완주하지 못한 선수/hyunwoo.py
+++ b/Hash/완주하지 못한 선수/hyunwoo.py
@@ -1,0 +1,15 @@
+def solution(participant, completion):
+    answer = {}
+    for el in participant:
+        if el in answer:
+            answer[el] += 1
+        else:
+            answer[el] = 1
+    
+    for el in completion:
+        answer[el] -= 1
+        if answer[el] == 0:
+            del answer[el]
+    
+    
+    return list(answer.keys())[0]

--- a/Hash/위장/hyunwoo.py
+++ b/Hash/위장/hyunwoo.py
@@ -1,0 +1,13 @@
+def solution(clothes):
+    clothes_dict = {}
+    for value, key in clothes:
+        if key in clothes_dict:
+            clothes_dict[key] += 1
+        else:
+            clothes_dict[key] = 1
+    clothes_values = list(clothes_dict.values())
+    answer = 1
+    for value in clothes_values:
+        answer *= (value + 1)
+        
+    return answer - 1

--- a/Hash/전화번호 목록/hyunwoo.py
+++ b/Hash/전화번호 목록/hyunwoo.py
@@ -1,0 +1,7 @@
+def solution(phone_book):
+    # 같은 글자 크기는 서로 다를 수 밖에 없음
+    phone_book.sort()
+    for i in range(len(phone_book) - 1):
+        if phone_book[i + 1].startswith(phone_book[i]):
+            return False
+    return True


### PR DESCRIPTION
## 완주하지 못한 선수

### 풀이

참가자 배열을 탐색하면서 딕셔너리에 +1을 해주었고, 다시 완주한 선수 배열을 탐색하면서 -1을 해주었다.
최종적으로 남은 인원이 완주하지 못한 선수가 된다.



## 위장

### 풀이

 수학 경우의 수를 이용하면 쉽게 해결할 수 있는 문제였다. 각 부위 별로 나올 수 있는 경우의 수에 +1을 하고 서로 곱해준 뒤,
-1을 해주면 답이 나오게 된다.



## 전화번호 목록

### 풀이 

문자열을 정렬하면, 길이에 상관없이 앞에서부터 비교하면서 문자열 배열이 정렬이 된다. 
세 수 a, b, c가 있을 때, 한 수가 다른 수의 접두어가 되는 경우는, a - b, b - c 관계밖에 없다. 
그렇기 때문에 for 문을 돌며 두 수를 비교하면 된다.

```
def solution(phone_book):
    phone_book.sort()
    for i in range(len(phone_book) - 1):
        if phone_book[i + 1].startswith(phone_book[i]):
            return False
    return True
```

## 느낀 점
해시의 경우, 문제가 너무 쉽게 나온 것 같았다. 하지만 다른 사람의 풀이를 보면서, Counter를 활용하는 방법 등 좀더 pythonic하게 풀 수 있는 방법을 배울 수 있었다.